### PR TITLE
Modified DSL methods to convert values to string

### DIFF
--- a/lib/pragmatic_context/contextualizable.rb
+++ b/lib/pragmatic_context/contextualizable.rb
@@ -16,11 +16,12 @@ module PragmaticContext
 
       def contextualize(field, params)
         setup_default_contextualizer
+        params.each { |k, v| params[k] = v.to_s }
         self.contextualizer.add_term(field, params)
       end
 
       def contextualize_as_type(type)
-        self.contextualized_type = type
+        self.contextualized_type = type.nil? ? type : type.to_s
       end
 
       private

--- a/spec/lib/pragmatic_context/contextualizable_spec.rb
+++ b/spec/lib/pragmatic_context/contextualizable_spec.rb
@@ -43,12 +43,23 @@ describe PragmaticContext::Contextualizable do
 
         subject.contextualize :bacon, :as => 'http://bacon.yum'
       end
+
+      it 'should coerce the param values to string' do
+        contextualizer = double('contextualizer')
+        contextualizer.should_receive(:add_term).with(:bacon, { :as => 'http://bacon.yum' })
+        PragmaticContext::DefaultContextualizer.stub(:new) { contextualizer }
+        subject.contextualize :bacon, :as => double(to_s: 'http://bacon.yum')
+      end
     end
 
     describe 'contextualize_as_type' do
       it 'should set the type on the class' do
         subject.contextualize_as_type 'bacon'
         subject.contextualized_type.should eq 'bacon'
+      end
+      it 'should coerce the type to string' do
+        subject.contextualize_as_type double(to_s: "http://schema.org/Person")
+        subject.contextualized_type.should eq "http://schema.org/Person"
       end
     end
   end


### PR DESCRIPTION
This change was made in order to support using
an RDF::URI or RDF::Vocabulary::Term (from RDF.rb)
with `contextualize_as_type` and `contextualize`.
